### PR TITLE
Quickfix for new URL structure in Coolrom's direct download link

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -90,7 +90,8 @@ parser.getRomDownloadLink = function(id, callback) {
 	var $;
 	scrapper.getRomDownloadLink(id, function (err, body, resp){
 		if (err) return callback(err);
-		var link = body.match(/(http:\/\/)+(fs)+[0-9]+(\.coolrom\.com)+[^\,\'\\]{0,}/g)[1];
+		var link = body.match(/(http:\/\/)+(.*\.coolrom.com\/dl\/.*\/.*\/.*\/")/g)[0];
+		link = link.substring(0, link.length - 1)
 		callback(err, link);
 	});
 };


### PR DESCRIPTION
## Coolrom direct download URL structure

I guess Coolrom changed it's direct download URL structure, which caused the parser to crash with an index out of bounds exception on line 93 (accessing element [1] on null). This is a quickfix, but might as well contribute (:
